### PR TITLE
Fix: Update android braintree gradle to stable version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ android {
 dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.facebook.react:react-native:+"
-    compile 'com.braintreepayments.api:braintree:2.+'
+    compile 'com.braintreepayments.api:braintree:2.3.9'
     compile 'com.braintreepayments.api:drop-in:2.+'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.3.1'
 }


### PR DESCRIPTION
# Trello
No Trello

# Describe
This will help solve the hanging loading which is described here https://github.com/kraffslol/react-native-braintree-xplat/issues/21